### PR TITLE
Update BW field name

### DIFF
--- a/Sources/NDT7Measurement.swift
+++ b/Sources/NDT7Measurement.swift
@@ -115,7 +115,7 @@ public struct NDT7BBRInfo: Codable {
     /// coding keys for codable purpose.
     enum CodingKeys: String, CodingKey {
         case elapsedTime = "ElapsedTime"
-        case bandwith = "MaxBandwidth"
+        case bandwith = "BW"
         case minRtt = "MinRTT"
     }
 }

--- a/Tests/NDT7MeasurementTests.swift
+++ b/Tests/NDT7MeasurementTests.swift
@@ -20,7 +20,7 @@ class NDT7MeasurementTests: XCTestCase {
  },
  "BBRInfo": {
    "ElapsedTime": 123,
-   "MaxBandwidth": 456,
+   "BW": 456,
    "MinRTT": 789
  },
 "ConnectionInfo": {


### PR DESCRIPTION
After https://github.com/m-lab/ndt-server/pull/273 the BBRInfo struct field name for `MaxBandwidth` is replaced with `BW`.

This change updates the swift translation for "bandwidth" to use the "BW" key. This change also updates the unit test sample JSON.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-ios/73)
<!-- Reviewable:end -->
