### PR TITLE
Consume the Locate V2 API. Use authenticated WSS urls for the speed test.

### DIFF
--- a/Example/Sources/ViewController.swift
+++ b/Example/Sources/ViewController.swift
@@ -106,7 +106,7 @@ extension ViewController: NDT7TestInteraction {
     }
 
     func measurement(origin: NDT7TestConstants.Origin, kind: NDT7TestConstants.Kind, measurement: NDT7Measurement) {
-        if let url = ndt7Test?.settings.url.hostname {
+        if let url = ndt7Test?.settings.hostname {
             serverLabel.text = url
         }
         if origin == .client,

--- a/NDT7.xcodeproj/project.pbxproj
+++ b/NDT7.xcodeproj/project.pbxproj
@@ -146,7 +146,7 @@
 		88E34DA3226E720900067D4F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E34DA1226E720900067D4F /* Constants.swift */; };
 		88E34DA4226E720900067D4F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E34DA1226E720900067D4F /* Constants.swift */; };
 		88E34DA5226E720900067D4F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E34DA1226E720900067D4F /* Constants.swift */; };
-		9CD7B7FE254B1502004E9A7D /* Asurion-Private-NDT7.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 9CD7B7FD254B1502004E9A7D /* Asurion-Private-NDT7.podspec */; };
+		9CEC7D74255B2C1800099967 /* NDT7.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 9CEC7D73255B2C1800099967 /* NDT7.podspec */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -219,7 +219,7 @@
 		8891D9662268DB6A000BF913 /* NDT7Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NDT7Settings.swift; sourceTree = "<group>"; };
 		88D408F8226F7C09002D889D /* ConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsTests.swift; sourceTree = "<group>"; };
 		88E34DA1226E720900067D4F /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		9CD7B7FD254B1502004E9A7D /* Asurion-Private-NDT7.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Asurion-Private-NDT7.podspec"; sourceTree = "<group>"; };
+		9CEC7D73255B2C1800099967 /* NDT7.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = NDT7.podspec; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -320,7 +320,7 @@
 		49BE5B72224EAA3900DB7BDF = {
 			isa = PBXGroup;
 			children = (
-				9CD7B7FD254B1502004E9A7D /* Asurion-Private-NDT7.podspec */,
+				9CEC7D73255B2C1800099967 /* NDT7.podspec */,
 				49BE5BD8224EC8F100DB7BDF /* Deployment */,
 				49BE5B96224EAB1A00DB7BDF /* Documentation */,
 				49BE5B7E224EAA3900DB7BDF /* Sources */,
@@ -701,7 +701,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9CD7B7FE254B1502004E9A7D /* Asurion-Private-NDT7.podspec in Resources */,
+				9CEC7D74255B2C1800099967 /* NDT7.podspec in Resources */,
 				49BE5B9C224EAB7300DB7BDF /* LICENSE in Resources */,
 				49BE5B9A224EAB5C00DB7BDF /* README.md in Resources */,
 				49BE5B98224EAB5200DB7BDF /* AUTHORS in Resources */,

--- a/NDT7.xcodeproj/project.pbxproj
+++ b/NDT7.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 
 /* Begin PBXBuildFile section */
 		4953B8B82257B24C00C3F002 /* NDT7.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49BE5BA9224EB9D000DB7BDF /* NDT7.framework */; };
-		4953B8BB2257D30500C3F002 /* NDT7.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 4953B8BA2257D30500C3F002 /* NDT7.podspec */; };
 		496107F9225EB04B00678DF8 /* LogNDT7Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496107F8225EB04B00678DF8 /* LogNDT7Tests.swift */; };
 		496107FE225EB0A400678DF8 /* LogNDT7Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496107F8225EB04B00678DF8 /* LogNDT7Tests.swift */; };
 		496107FF225EB0A500678DF8 /* LogNDT7Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496107F8225EB04B00678DF8 /* LogNDT7Tests.swift */; };
@@ -147,6 +146,7 @@
 		88E34DA3226E720900067D4F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E34DA1226E720900067D4F /* Constants.swift */; };
 		88E34DA4226E720900067D4F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E34DA1226E720900067D4F /* Constants.swift */; };
 		88E34DA5226E720900067D4F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E34DA1226E720900067D4F /* Constants.swift */; };
+		9CD7B7FE254B1502004E9A7D /* Asurion-Private-NDT7.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 9CD7B7FD254B1502004E9A7D /* Asurion-Private-NDT7.podspec */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -219,6 +219,7 @@
 		8891D9662268DB6A000BF913 /* NDT7Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NDT7Settings.swift; sourceTree = "<group>"; };
 		88D408F8226F7C09002D889D /* ConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsTests.swift; sourceTree = "<group>"; };
 		88E34DA1226E720900067D4F /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		9CD7B7FD254B1502004E9A7D /* Asurion-Private-NDT7.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Asurion-Private-NDT7.podspec"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -319,6 +320,7 @@
 		49BE5B72224EAA3900DB7BDF = {
 			isa = PBXGroup;
 			children = (
+				9CD7B7FD254B1502004E9A7D /* Asurion-Private-NDT7.podspec */,
 				49BE5BD8224EC8F100DB7BDF /* Deployment */,
 				49BE5B96224EAB1A00DB7BDF /* Documentation */,
 				49BE5B7E224EAA3900DB7BDF /* Sources */,
@@ -699,8 +701,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9CD7B7FE254B1502004E9A7D /* Asurion-Private-NDT7.podspec in Resources */,
 				49BE5B9C224EAB7300DB7BDF /* LICENSE in Resources */,
-				4953B8BB2257D30500C3F002 /* NDT7.podspec in Resources */,
 				49BE5B9A224EAB5C00DB7BDF /* README.md in Resources */,
 				49BE5B98224EAB5200DB7BDF /* AUTHORS in Resources */,
 			);

--- a/NDT7.xcodeproj/xcshareddata/xcschemes/NDT7 macOS.xcscheme
+++ b/NDT7.xcodeproj/xcshareddata/xcschemes/NDT7 macOS.xcscheme
@@ -26,9 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "49BE5B9D224EB9D000DB7BDF"
+            BuildableName = "NDT7.framework"
+            BlueprintName = "NDT7 macOS"
+            ReferencedContainer = "container:NDT7.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -50,17 +59,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "49BE5B9D224EB9D000DB7BDF"
-            BuildableName = "NDT7.framework"
-            BlueprintName = "NDT7 macOS"
-            ReferencedContainer = "container:NDT7.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -81,8 +79,6 @@
             ReferencedContainer = "container:NDT7.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -63,6 +63,8 @@ public struct NDT7WebSocketConstants {
 
         /// Discover closer Mlab Server
         public static let url = "https://\(hostname)/\(path)"
+        
+        public static let urlv2 = "https://locate.measurementlab.net/v2/nearest/ndt/ndt7"
 
         /// Cannot find a suitable mlab server error
         public static let noMlabServerError = NSError(domain: NDT7WebSocketConstants.domain,

--- a/Sources/NDT7Test.swift
+++ b/Sources/NDT7Test.swift
@@ -139,21 +139,21 @@ extension NDT7Test {
     /// - parameter error: returns an error if exist.
     func serverSetup<T: URLSessionNDT7>(session: T = URLSession.shared as! T,
                                         _ completion: @escaping (_ error: NSError?) -> Void) {
-        discoverServerTask = NDT7ServerV2.discoverV2(session: session, { [weak self] (server, error) in
+        discoverServerTask = NDT7ServerV2.discoverV2(session: session, { [weak self] (servers, error) in
             guard let strongSelf = self else { return }
             guard error == nil else { completion(error); return }
-            guard let server = server, server.count != 0 else {
+            guard let servers = servers, !servers.isEmpty else {
                 let setupError = NSError(domain: NDT7WebSocketConstants.domain, code: 0,                                       userInfo: [ NSLocalizedDescriptionKey: "Failed to locate a valid mlab server to contact"])
                 completion(setupError)
                 return
             }
             
             // Save all server options, load the first server's information in to try to use it first
-            strongSelf.settings.allServers = server
+            strongSelf.settings.allServers = servers
             strongSelf.settings.currentServerIndex = 0
-            strongSelf.settings.hostname = server[0].machine
-            strongSelf.settings.downloadUrl = server[0].urls.downloadUrl
-            strongSelf.settings.uploadUrl = server[0].urls.uploadUrl
+            strongSelf.settings.hostname = servers[0].machine
+            strongSelf.settings.downloadUrl = servers[0].urls.downloadUrl
+            strongSelf.settings.uploadUrl = servers[0].urls.uploadUrl
             
             completion(error)
         })

--- a/Tests/NDT7SettingsTests.swift
+++ b/Tests/NDT7SettingsTests.swift
@@ -38,15 +38,72 @@ class URLSessionDataTaskMock: URLSessionTaskNDT7 {
     }
 }
 
+let jsonServerData = """
+{
+  "results": [
+    {
+      "machine": "mlab1-atl02.mlab-oti.measurement-lab.org",
+      "location": {
+        "city": "Atlanta",
+        "country": "US"
+      },
+      "urls": {
+        "ws:///ndt/v7/download": "ws://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ",
+        "ws:///ndt/v7/upload": "ws://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ",
+        "wss:///ndt/v7/download": "wss://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ",
+        "wss:///ndt/v7/upload": "wss://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ"
+      }
+    },
+    {
+      "machine": "mlab1-atl03.mlab-oti.measurement-lab.org",
+      "location": {
+        "city": "Atlanta",
+        "country": "US"
+      },
+      "urls": {
+        "ws:///ndt/v7/download": "ws://ndt-mlab1-atl03.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDMubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAzLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.zgCcTD5FsdAMjEFGqAHB1tiQpEcS7zbMIXwBEUmIfOFiZN4r3lwfUSrTMm4QbKsrhCBjb7ztkAvOr87yuzs9Bw",
+        "ws:///ndt/v7/upload": "ws://ndt-mlab1-atl03.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDMubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAzLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.zgCcTD5FsdAMjEFGqAHB1tiQpEcS7zbMIXwBEUmIfOFiZN4r3lwfUSrTMm4QbKsrhCBjb7ztkAvOr87yuzs9Bw",
+        "wss:///ndt/v7/download": "wss://ndt-mlab1-atl03.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDMubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAzLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.zgCcTD5FsdAMjEFGqAHB1tiQpEcS7zbMIXwBEUmIfOFiZN4r3lwfUSrTMm4QbKsrhCBjb7ztkAvOr87yuzs9Bw",
+        "wss:///ndt/v7/upload": "wss://ndt-mlab1-atl03.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDMubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAzLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.zgCcTD5FsdAMjEFGqAHB1tiQpEcS7zbMIXwBEUmIfOFiZN4r3lwfUSrTMm4QbKsrhCBjb7ztkAvOr87yuzs9Bw"
+      }
+    },
+    {
+      "machine": "mlab3-atl08.mlab-oti.measurement-lab.org",
+      "location": {
+        "city": "Atlanta",
+        "country": "US"
+      },
+      "urls": {
+        "ws:///ndt/v7/download": "ws://ndt-mlab3-atl08.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjMtYXRsMDgubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIzLmF0bDA4Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.EBdE0ub_VIxxXn_3Pk8kqG31e3iIDaR0fniPrTXFEdnKpTeepUTOIr0QbovfspMnuRBtVqD0YPBXidPR0mesAA",
+        "ws:///ndt/v7/upload": "ws://ndt-mlab3-atl08.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjMtYXRsMDgubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIzLmF0bDA4Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.EBdE0ub_VIxxXn_3Pk8kqG31e3iIDaR0fniPrTXFEdnKpTeepUTOIr0QbovfspMnuRBtVqD0YPBXidPR0mesAA",
+        "wss:///ndt/v7/download": "wss://ndt-mlab3-atl08.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjMtYXRsMDgubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIzLmF0bDA4Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.EBdE0ub_VIxxXn_3Pk8kqG31e3iIDaR0fniPrTXFEdnKpTeepUTOIr0QbovfspMnuRBtVqD0YPBXidPR0mesAA",
+        "wss:///ndt/v7/upload": "wss://ndt-mlab3-atl08.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjMtYXRsMDgubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIzLmF0bDA4Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.EBdE0ub_VIxxXn_3Pk8kqG31e3iIDaR0fniPrTXFEdnKpTeepUTOIr0QbovfspMnuRBtVqD0YPBXidPR0mesAA"
+      }
+    },
+    {
+      "machine": "mlab1-atl04.mlab-oti.measurement-lab.org",
+      "location": {
+        "city": "Atlanta",
+        "country": "US"
+      },
+      "urls": {
+        "ws:///ndt/v7/download": "ws://ndt-mlab1-atl04.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDQubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDA0Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.q3IgAwb5Y57QIQ3mEgfdU39RSTvEB08GDJfdMdcI5kjn6SdLkhIWBggu4I_l48W3vmXuRoCT14c7bCrqVBRgDQ",
+        "ws:///ndt/v7/upload": "ws://ndt-mlab1-atl04.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDQubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDA0Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.q3IgAwb5Y57QIQ3mEgfdU39RSTvEB08GDJfdMdcI5kjn6SdLkhIWBggu4I_l48W3vmXuRoCT14c7bCrqVBRgDQ",
+        "wss:///ndt/v7/download": "wss://ndt-mlab1-atl04.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDQubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDA0Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.q3IgAwb5Y57QIQ3mEgfdU39RSTvEB08GDJfdMdcI5kjn6SdLkhIWBggu4I_l48W3vmXuRoCT14c7bCrqVBRgDQ",
+        "wss:///ndt/v7/upload": "wss://ndt-mlab1-atl04.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDQubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDA0Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.q3IgAwb5Y57QIQ3mEgfdU39RSTvEB08GDJfdMdcI5kjn6SdLkhIWBggu4I_l48W3vmXuRoCT14c7bCrqVBRgDQ"
+      }
+    }
+  ]
+}
+""".data(using: .utf8)
+
 class NDT7SettingsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        NDT7Server.lastServer = nil
     }
 
     override func tearDown() {
-        NDT7Server.lastServer = nil
         super.tearDown()
     }
 
@@ -56,17 +113,6 @@ class NDT7SettingsTests: XCTestCase {
         XCTAssertEqual(defaultSettings.headers["Sec-WebSocket-Protocol"], "net.measurementlab.ndt.v7")
     }
 
-    func testNDT7URLDefault() {
-        let defaultURL = NDT7URL(hostname: "")
-        XCTAssertNil(defaultURL.server)
-        XCTAssertEqual(defaultURL.hostname, "")
-        XCTAssertEqual(defaultURL.downloadPath, "/ndt/v7/download")
-        XCTAssertEqual(defaultURL.uploadPath, "/ndt/v7/upload")
-        XCTAssertTrue(defaultURL.wss)
-        XCTAssertEqual(defaultURL.download, "wss:///ndt/v7/download")
-        XCTAssertEqual(defaultURL.upload, "wss:///ndt/v7/upload")
-    }
-
     func testNDT7TimeoutsDefault() {
         let defaultTimeouts = NDT7Timeouts()
         XCTAssertEqual(defaultTimeouts.measurement, 0.25)
@@ -74,162 +120,42 @@ class NDT7SettingsTests: XCTestCase {
         XCTAssertEqual(defaultTimeouts.downloadTimeout, 15)
         XCTAssertEqual(defaultTimeouts.uploadTimeout, 15)
     }
-
-    func testDiscoverServer() {
-
-        // 1. The server is discovered without geo options enabled (NDT7 server cache disabled).
+    
+    /// Validates that we read the correct URLs to run the tests against from the Locate API V2
+    func testDiscoverServerV2() {
+        // Prepare mock data
         let session = URLSessionMock()
-        let jsonServerData = """
-        {\"ip\": [\"70.42.177.114\", \"2600:c0b:2002:5::114\"], \"country\": \"US\", \"city\": \"Atlanta_GA\", \"fqdn\": \"ndt-iupui-mlab4-atl06.measurement-lab.org\", \"site\": \"atl06\"}
-        """.data(using: .utf8)
         session.data = jsonServerData
         var result = false
-        var serverResult: NDT7Server?
+        var serverResult: [NDT7ServerV2]?
         let expectation = XCTestExpectation(description: "Job in main thread")
-        _ = NDT7Server.discover(session: session,
-                                withGeoOptions: false,
-                                retray: 100,
-                                geoOptionsChangeInRetray: false, { (server, _) in
-                                    serverResult = server
-                                    result = true
-                                    expectation.fulfill()
+        
+        // Call discovery
+        _ = NDT7ServerV2.discoverV2(session: session, { (server, _) in
+            serverResult = server
+            result = true
+            expectation.fulfill()
         })
-        wait(for: [expectation], timeout: 10.0)
+        wait(for: [expectation], timeout: 5.0)
+        
+        // Assert
         XCTAssertTrue(result)
         XCTAssertNotNil(serverResult)
-        XCTAssertTrue(serverResult?.ip?.contains("70.42.177.114") != nil)
-        XCTAssertTrue(serverResult?.ip?.contains("2600:c0b:2002:5::114") != nil)
-        XCTAssertEqual(serverResult?.country, "US")
-        XCTAssertEqual(serverResult?.city, "Atlanta_GA")
-        XCTAssertEqual(serverResult?.fqdn, "ndt-iupui-mlab4-atl06.measurement-lab.org")
-        XCTAssertEqual(serverResult?.site, "atl06")
-
-        // 2. The server is discovered with geo options enabled (NDT7 server cache disabled).
-        let jsonServerListData1 = """
-        [{\"ip\": [\"70.42.177.114\", \"2600:c0b:2002:5::114\"], \"country\": \"US\", \"city\": \"Atlanta_GA\", \"fqdn\": \"ndt-iupui-mlab4-atl06.measurement-lab.org\", \"site\": \"atl06\"}]
-        """.data(using: .utf8)
-        session.data = jsonServerListData1
-        var resultWithGeoOptions1 = false
-        let expectationGeoOptions1 = XCTestExpectation(description: "Job in main thread")
-        _ = NDT7Server.discover(session: session,
-                                withGeoOptions: true,
-                                retray: 100,
-                                geoOptionsChangeInRetray: false, { (server, _) in
-                                    serverResult = server
-                                    resultWithGeoOptions1 = true
-                                    expectationGeoOptions1.fulfill()
-        })
-        wait(for: [expectationGeoOptions1], timeout: 10.0)
-        XCTAssertTrue(resultWithGeoOptions1)
-        XCTAssertNotNil(serverResult)
-        XCTAssertTrue(serverResult?.ip?.contains("70.42.177.114") != nil)
-        XCTAssertTrue(serverResult?.ip?.contains("2600:c0b:2002:5::114") != nil)
-        XCTAssertEqual(serverResult?.country, "US")
-        XCTAssertEqual(serverResult?.city, "Atlanta_GA")
-        XCTAssertEqual(serverResult?.fqdn, "ndt-iupui-mlab4-atl06.measurement-lab.org")
-        XCTAssertEqual(serverResult?.site, "atl06")
-
-        // 3. if there is an error getting a new server, the server can't be discovered (NDT7 server cache disabled).
-        let jsonServerListData3 = """
-        [{\"ip\": [\"70.42.177.114\", \"2600:c0b:2002:5::114\"], \"country\": \"US\", \"city\": \"Atlanta_GA\", \"site\": \"atl06\"}]
-        """.data(using: .utf8)
-        session.data = jsonServerListData3
-        var resultWithGeoOptions3 = false
-        let expectationGeoOptions3 = XCTestExpectation(description: "Job in main thread")
-        _ = NDT7Server.discover(session: session,
-                                withGeoOptions: true,
-                                retray: 100,
-                                geoOptionsChangeInRetray: false, { (server, _) in
-                                    serverResult = server
-                                    resultWithGeoOptions3 = true
-                                    expectationGeoOptions3.fulfill()
-        })
-        wait(for: [expectationGeoOptions3], timeout: 10.0)
-        XCTAssertTrue(resultWithGeoOptions3)
-        XCTAssertNil(serverResult)
+        XCTAssertEqual(serverResult?[0].urls.uploadUrl, "wss://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ")
+        XCTAssertEqual(serverResult?[0].urls.downloadUrl, "wss://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ")
+        XCTAssertEqual(serverResult?[0].urls.insecureUploadUrl, "ws://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ")
+        XCTAssertEqual(serverResult?[0].urls.insecureDownloadUrl, "ws://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ")
     }
 
-    func testDiscoverServerUsingNDT7ServerCache() {
-
-        // The server is discovered without geo options enabled and saved in cache.
-        let session = URLSessionMock()
-        let jsonServerData = """
-        {\"ip\": [\"70.42.177.114\", \"2600:c0b:2002:5::114\"], \"country\": \"US\", \"city\": \"Atlanta_GA\", \"fqdn\": \"ndt-iupui-mlab4-atl06.measurement-lab.org\", \"site\": \"atl06\"}
-        """.data(using: .utf8)
-        session.data = jsonServerData
-        var result = false
-        var serverResult: NDT7Server?
-        let expectation = XCTestExpectation(description: "Job in main thread")
-        _ = NDT7Server.discover(session: session,
-                                withGeoOptions: false,
-                                retray: 100,
-                                geoOptionsChangeInRetray: false, { (server, _) in
-                                    serverResult = server
-                                    result = true
-                                    expectation.fulfill()
-        })
-        wait(for: [expectation], timeout: 10.0)
-        XCTAssertTrue(result)
-        XCTAssertNotNil(serverResult)
-        XCTAssertTrue(serverResult?.ip?.contains("70.42.177.114") != nil)
-        XCTAssertTrue(serverResult?.ip?.contains("2600:c0b:2002:5::114") != nil)
-        XCTAssertEqual(serverResult?.country, "US")
-        XCTAssertEqual(serverResult?.city, "Atlanta_GA")
-        XCTAssertEqual(serverResult?.fqdn, "ndt-iupui-mlab4-atl06.measurement-lab.org")
-        XCTAssertEqual(serverResult?.site, "atl06")
-
-        // If the server discovery is returning errors, the discovery returns the last server discovered if getting the server in cache is enabled.
-        let jsonServerListData5 = """
-        """.data(using: .utf8)
-        session.data = jsonServerListData5
-        session.error = NDT7WebSocketConstants.MlabServerDiscover.noMlabServerError
-        var errorResult: Error?
-        var resultWithGeoOptions5 = false
-        let expectationGeoOptions5 = XCTestExpectation(description: "Job in main thread")
-        _ = NDT7Server.discover(session: session,
-                                withGeoOptions: true,
-                                retray: 100,
-                                geoOptionsChangeInRetray: false,
-                                useNDT7ServerCache: true, { (server, error) in
-                                    errorResult = error
-                                    serverResult = server
-                                    resultWithGeoOptions5 = true
-                                    expectationGeoOptions5.fulfill()
-        })
-        wait(for: [expectationGeoOptions5], timeout: 10.0)
-        XCTAssertTrue(resultWithGeoOptions5)
-        XCTAssertNotNil(serverResult)
-        XCTAssertNil(errorResult)
-        XCTAssertTrue(serverResult?.ip?.contains("70.42.177.114") != nil)
-        XCTAssertTrue(serverResult?.ip?.contains("2600:c0b:2002:5::114") != nil)
-        XCTAssertEqual(serverResult?.country, "US")
-        XCTAssertEqual(serverResult?.city, "Atlanta_GA")
-        XCTAssertEqual(serverResult?.fqdn, "ndt-iupui-mlab4-atl06.measurement-lab.org")
-        XCTAssertEqual(serverResult?.site, "atl06")
-    }
-
-    func testDecodeServer() {
-        let jsonServer = """
-{\"ip\": [\"70.42.177.114\", \"2600:c0b:2002:5::114\"], \"country\": \"US\", \"city\": \"Atlanta_GA\", \"fqdn\": \"ndt-iupui-mlab4-atl06.measurement-lab.org\", \"site\": \"atl06\"}
-"""
-        let server = NDT7Server.decode(data: jsonServer.data(using: .utf8), fromUrl: NDT7WebSocketConstants.MlabServerDiscover.url)
-        XCTAssertTrue(server?.ip?.contains("70.42.177.114") != nil)
-        XCTAssertTrue(server?.ip?.contains("2600:c0b:2002:5::114") != nil)
-        XCTAssertEqual(server?.country, "US")
-        XCTAssertEqual(server?.city, "Atlanta_GA")
-        XCTAssertEqual(server?.fqdn, "ndt-iupui-mlab4-atl06.measurement-lab.org")
-        XCTAssertEqual(server?.site, "atl06")
-        let jsonServerList = """
-[{\"ip\": [\"70.42.177.114\", \"2600:c0b:2002:5::114\"], \"country\": \"US\", \"city\": \"Atlanta_GA\", \"fqdn\": \"ndt-iupui-mlab4-atl06.measurement-lab.org\", \"site\": \"atl06\"}]
-"""
-        let serverFromList = NDT7Server.decode(data: jsonServerList.data(using: .utf8), fromUrl: NDT7WebSocketConstants.MlabServerDiscover.urlWithGeoOption)
-        XCTAssertTrue(serverFromList?.ip?.contains("70.42.177.114") != nil)
-        XCTAssertTrue(serverFromList?.ip?.contains("2600:c0b:2002:5::114") != nil)
-        XCTAssertEqual(serverFromList?.country, "US")
-        XCTAssertEqual(serverFromList?.city, "Atlanta_GA")
-        XCTAssertEqual(serverFromList?.fqdn, "ndt-iupui-mlab4-atl06.measurement-lab.org")
-        XCTAssertEqual(serverFromList?.site, "atl06")
-        let noServerFromList = NDT7Server.decode(data: jsonServerList.data(using: .utf8), fromUrl: "empty")
-        XCTAssertNil(noServerFromList)
+    func testDecodeServer() throws {
+        let apiResponse = try? JSONDecoder().decode(LocateAPIV2Response.self, from: jsonServerData!)
+        let maybeServer = apiResponse?.results[0]
+        guard let server = maybeServer else { XCTFail(); return}
+        
+        // Assert the contents of the server
+        XCTAssertEqual(server.machine, "mlab1-atl02.mlab-oti.measurement-lab.org")
+        XCTAssertEqual(server.location.city, "Atlanta")
+        XCTAssertEqual(server.location.country, "US")
+        XCTAssertEqual(server.urls.downloadUrl, "wss://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ")
     }
 }

--- a/Tests/NDT7SettingsTests.swift
+++ b/Tests/NDT7SettingsTests.swift
@@ -127,11 +127,11 @@ class NDT7SettingsTests: XCTestCase {
         let session = URLSessionMock()
         session.data = jsonServerData
         var result = false
-        var serverResult: [NDT7ServerV2]?
+        var serverResult: [NDT7Server]?
         let expectation = XCTestExpectation(description: "Job in main thread")
         
         // Call discovery
-        _ = NDT7ServerV2.discoverV2(session: session, { (server, _) in
+        _ = NDT7Server.discoverV2(session: session, { (server, _) in
             serverResult = server
             result = true
             expectation.fulfill()
@@ -148,7 +148,7 @@ class NDT7SettingsTests: XCTestCase {
     }
 
     func testDecodeServer() throws {
-        let apiResponse = try? JSONDecoder().decode(LocateAPIV2Response.self, from: jsonServerData!)
+        let apiResponse = try? JSONDecoder().decode(LocateAPIResponse.self, from: jsonServerData!)
         let maybeServer = apiResponse?.results[0]
         guard let server = maybeServer else { XCTFail(); return}
         

--- a/Tests/NDT7TestTests.swift
+++ b/Tests/NDT7TestTests.swift
@@ -12,20 +12,71 @@ import XCTest
 class NDT7TestTests: XCTestCase {
 
     let jsonServerData = """
-    {\"ip\": [\"70.42.177.114\", \"2600:c0b:2002:5::114\"], \"country\": \"US\", \"city\": \"Atlanta_GA\", \"fqdn\": \"ndt-iupui-mlab4-atl06.measurement-lab.org\", \"site\": \"atl06\"}
+    {
+      "results": [
+        {
+          "machine": "mlab1-atl02.mlab-oti.measurement-lab.org",
+          "location": {
+            "city": "Atlanta",
+            "country": "US"
+          },
+          "urls": {
+            "ws:///ndt/v7/download": "ws://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ",
+            "ws:///ndt/v7/upload": "ws://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ",
+            "wss:///ndt/v7/download": "wss://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ",
+            "wss:///ndt/v7/upload": "wss://ndt-mlab1-atl02.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDIubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAyLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.22owCDnIB0aM8Kd3NZ7GmtA-WcLz_0hvrkMbumq-B4QAM1ZBlFqGp7zHGLzainLjEhbqb4JHV56v56CYNayyAQ"
+          }
+        },
+        {
+          "machine": "mlab1-atl03.mlab-oti.measurement-lab.org",
+          "location": {
+            "city": "Atlanta",
+            "country": "US"
+          },
+          "urls": {
+            "ws:///ndt/v7/download": "ws://ndt-mlab1-atl03.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDMubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAzLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.zgCcTD5FsdAMjEFGqAHB1tiQpEcS7zbMIXwBEUmIfOFiZN4r3lwfUSrTMm4QbKsrhCBjb7ztkAvOr87yuzs9Bw",
+            "ws:///ndt/v7/upload": "ws://ndt-mlab1-atl03.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDMubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAzLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.zgCcTD5FsdAMjEFGqAHB1tiQpEcS7zbMIXwBEUmIfOFiZN4r3lwfUSrTMm4QbKsrhCBjb7ztkAvOr87yuzs9Bw",
+            "wss:///ndt/v7/download": "wss://ndt-mlab1-atl03.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDMubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAzLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.zgCcTD5FsdAMjEFGqAHB1tiQpEcS7zbMIXwBEUmIfOFiZN4r3lwfUSrTMm4QbKsrhCBjb7ztkAvOr87yuzs9Bw",
+            "wss:///ndt/v7/upload": "wss://ndt-mlab1-atl03.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDMubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDAzLm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.zgCcTD5FsdAMjEFGqAHB1tiQpEcS7zbMIXwBEUmIfOFiZN4r3lwfUSrTMm4QbKsrhCBjb7ztkAvOr87yuzs9Bw"
+          }
+        },
+        {
+          "machine": "mlab3-atl08.mlab-oti.measurement-lab.org",
+          "location": {
+            "city": "Atlanta",
+            "country": "US"
+          },
+          "urls": {
+            "ws:///ndt/v7/download": "ws://ndt-mlab3-atl08.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjMtYXRsMDgubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIzLmF0bDA4Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.EBdE0ub_VIxxXn_3Pk8kqG31e3iIDaR0fniPrTXFEdnKpTeepUTOIr0QbovfspMnuRBtVqD0YPBXidPR0mesAA",
+            "ws:///ndt/v7/upload": "ws://ndt-mlab3-atl08.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjMtYXRsMDgubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIzLmF0bDA4Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.EBdE0ub_VIxxXn_3Pk8kqG31e3iIDaR0fniPrTXFEdnKpTeepUTOIr0QbovfspMnuRBtVqD0YPBXidPR0mesAA",
+            "wss:///ndt/v7/download": "wss://ndt-mlab3-atl08.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjMtYXRsMDgubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIzLmF0bDA4Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.EBdE0ub_VIxxXn_3Pk8kqG31e3iIDaR0fniPrTXFEdnKpTeepUTOIr0QbovfspMnuRBtVqD0YPBXidPR0mesAA",
+            "wss:///ndt/v7/upload": "wss://ndt-mlab3-atl08.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjMtYXRsMDgubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIzLmF0bDA4Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.EBdE0ub_VIxxXn_3Pk8kqG31e3iIDaR0fniPrTXFEdnKpTeepUTOIr0QbovfspMnuRBtVqD0YPBXidPR0mesAA"
+          }
+        },
+        {
+          "machine": "mlab1-atl04.mlab-oti.measurement-lab.org",
+          "location": {
+            "city": "Atlanta",
+            "country": "US"
+          },
+          "urls": {
+            "ws:///ndt/v7/download": "ws://ndt-mlab1-atl04.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDQubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDA0Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.q3IgAwb5Y57QIQ3mEgfdU39RSTvEB08GDJfdMdcI5kjn6SdLkhIWBggu4I_l48W3vmXuRoCT14c7bCrqVBRgDQ",
+            "ws:///ndt/v7/upload": "ws://ndt-mlab1-atl04.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDQubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDA0Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.q3IgAwb5Y57QIQ3mEgfdU39RSTvEB08GDJfdMdcI5kjn6SdLkhIWBggu4I_l48W3vmXuRoCT14c7bCrqVBRgDQ",
+            "wss:///ndt/v7/download": "wss://ndt-mlab1-atl04.mlab-oti.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDQubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDA0Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.q3IgAwb5Y57QIQ3mEgfdU39RSTvEB08GDJfdMdcI5kjn6SdLkhIWBggu4I_l48W3vmXuRoCT14c7bCrqVBRgDQ",
+            "wss:///ndt/v7/upload": "wss://ndt-mlab1-atl04.mlab-oti.measurement-lab.org/ndt/v7/upload?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjEtYXRsMDQubWxhYi1vdGkubWVhc3VyZW1lbnQtbGFiLm9yZyIsIm1sYWIxLmF0bDA0Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjAzOTIxODE1LCJpc3MiOiJsb2NhdGUiLCJzdWIiOiJuZHQifQ.q3IgAwb5Y57QIQ3mEgfdU39RSTvEB08GDJfdMdcI5kjn6SdLkhIWBggu4I_l48W3vmXuRoCT14c7bCrqVBRgDQ"
+          }
+        }
+      ]
+    }
     """.data(using: .utf8)
-
-    let jsonServerDataNofqdn = """
-    {\"ip\": [\"70.42.177.114\", \"2600:c0b:2002:5::114\"], \"country\": \"US\", \"city\": \"Atlanta_GA\", \"site\": \"atl06\"}
-    """.data(using: .utf8)
+    
+    
 
     override func setUp() {
         super.setUp()
-        NDT7Server.lastServer = nil
     }
 
     override func tearDown() {
-        NDT7Server.lastServer = nil
         super.tearDown()
     }
 
@@ -57,7 +108,7 @@ class NDT7TestTests: XCTestCase {
 
     func testNdt7TestStartTestFalse() {
 
-        let settings = NDT7Settings(url: NDT7URL(hostname: "hostname.com", downloadPath: ""))
+        let settings = NDT7Settings()
         let ndt7Test: NDT7Test? = NDT7Test(settings: settings)
         var startDownloadCheck = false
         let downloadCompletion: (_ error: NSError?) -> Void = { (error) in
@@ -97,7 +148,7 @@ class NDT7TestTests: XCTestCase {
 
     func testNDT7TestCleanup() {
 
-        let settings = NDT7Settings(url: NDT7URL(hostname: "", downloadPath: ""))
+        let settings = NDT7Settings()
         let ndt7Test: NDT7Test? = NDT7Test(settings: settings)
         let downloadCompletion: (_ error: NSError?) -> Void = { (error) in
             XCTAssertNil(error)
@@ -122,14 +173,14 @@ class NDT7TestTests: XCTestCase {
     }
 
     func testServerSetup() throws {
-
-        var settings = NDT7Settings(url: NDT7URL(hostname: "hostname.com"))
-        var ndt7Test: NDT7Test? = NDT7Test(settings: settings)
         let session = URLSessionMock()
+        let settings = NDT7Settings()
+        let ndt7Test = NDT7Test(settings: settings)
+        session.data = jsonServerData
         var result = false
         var errorResult: Error?
-        var expectation = XCTestExpectation(description: "Job in main thread")
-        ndt7Test?.serverSetup(session: session, { (error) in
+        let expectation = XCTestExpectation(description: "Job in main thread")
+        ndt7Test.serverSetup(session: session, { (error) in
             result = true
             errorResult = error
             XCTAssertNil(error)
@@ -138,158 +189,10 @@ class NDT7TestTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
         XCTAssertTrue(result)
         XCTAssertNil(errorResult)
-        XCTAssertNil(ndt7Test?.settings.url.server)
-        var hostname = try XCTUnwrap(ndt7Test?.settings.url.hostname)
-        XCTAssertEqual(hostname, "hostname.com")
-
-        settings = NDT7Settings(url: NDT7URL(hostname: ""))
-        ndt7Test = NDT7Test(settings: settings)
-        session.data = jsonServerDataNofqdn
-        result = false
-        errorResult = nil
-        expectation = XCTestExpectation(description: "Job in main thread")
-        ndt7Test?.serverSetup(session: session, { (error) in
-            result = true
-            errorResult = error
-            XCTAssertNotNil(error)
-            expectation.fulfill()
-        })
-        wait(for: [expectation], timeout: 10.0)
-        XCTAssertTrue(result)
-        XCTAssertNotNil(errorResult)
-        let errorLocalizedDescription = try XCTUnwrap(errorResult)
-        XCTAssertEqual(errorLocalizedDescription.localizedDescription, "Cannot find a suitable mlab server")
-        XCTAssertNil(ndt7Test?.settings.url.server)
-        XCTAssertEqual(ndt7Test?.settings.url.hostname, "")
-        ndt7Test?.discoverServerTask = nil
-
-        settings = NDT7Settings(url: NDT7URL(hostname: ""))
-        ndt7Test = NDT7Test(settings: settings)
-        session.data = jsonServerData
-        result = false
-        errorResult = nil
-        expectation = XCTestExpectation(description: "Job in main thread")
-        ndt7Test?.serverSetup(session: session, { (error) in
-            result = true
-            errorResult = error
-            XCTAssertNil(error)
-            expectation.fulfill()
-        })
-        wait(for: [expectation], timeout: 10.0)
-        XCTAssertTrue(result)
-        XCTAssertNil(errorResult)
-        XCTAssertNotNil(ndt7Test?.settings.url.server)
-        hostname = try XCTUnwrap(ndt7Test?.settings.url.hostname)
-        XCTAssertEqual(hostname, "ndt-iupui-mlab4-atl06.measurement-lab.org")
-        ndt7Test?.discoverServerTask = nil
-
-        // After one successful server, if we don't get a successful server again and we have NDT7 server cache disabled (for default), we don't get the last server
-        settings = NDT7Settings(url: NDT7URL(hostname: ""))
-        ndt7Test = NDT7Test(settings: settings)
-        session.data = jsonServerDataNofqdn
-        result = false
-        errorResult = nil
-        expectation = XCTestExpectation(description: "Job in main thread")
-        ndt7Test?.serverSetup(session: session, { (error) in
-            result = true
-            errorResult = error
-            XCTAssertNotNil(error)
-            expectation.fulfill()
-        })
-        wait(for: [expectation], timeout: 10.0)
-        XCTAssertTrue(result)
-        XCTAssertNotNil(errorResult)
-        XCTAssertNil(ndt7Test?.settings.url.server)
-        hostname = try XCTUnwrap(ndt7Test?.settings.url.hostname)
-        XCTAssertEqual(hostname, "")
-        ndt7Test?.discoverServerTask = nil
-    }
-
-    func testServerSetupUsingNDT7ServerCache() throws {
-
-        // Request failure to get NDT7 server.
-        var settings = NDT7Settings(url: NDT7URL(hostname: "hostname.com"))
-        var ndt7Test: NDT7Test? = NDT7Test(settings: settings)
-        let session = URLSessionMock()
-        var result = false
-        var errorResult: Error?
-        var expectation = XCTestExpectation(description: "Job in main thread")
-        ndt7Test?.serverSetup(session: session, { (error) in
-            result = true
-            errorResult = error
-            XCTAssertNil(error)
-            expectation.fulfill()
-        })
-        wait(for: [expectation], timeout: 10.0)
-        XCTAssertTrue(result)
-        XCTAssertNil(errorResult)
-        XCTAssertNil(ndt7Test?.settings.url.server)
-        var hostname = try XCTUnwrap(ndt7Test?.settings.url.hostname)
-        XCTAssertEqual(hostname, "hostname.com")
-
-        // No server data found in the payload.
-        settings = NDT7Settings(url: NDT7URL(hostname: ""))
-        ndt7Test = NDT7Test(settings: settings)
-        session.data = jsonServerDataNofqdn
-        result = false
-        errorResult = nil
-        expectation = XCTestExpectation(description: "Job in main thread")
-        ndt7Test?.serverSetup(session: session, { (error) in
-            result = true
-            errorResult = error
-            XCTAssertNotNil(error)
-            expectation.fulfill()
-        })
-        wait(for: [expectation], timeout: 10.0)
-        XCTAssertTrue(result)
-        XCTAssertNotNil(errorResult)
-        let errorLocalizedDescription = try XCTUnwrap(errorResult?.localizedDescription)
-        XCTAssertEqual(errorLocalizedDescription, "Cannot find a suitable mlab server")
-        XCTAssertNil(ndt7Test?.settings.url.server)
-        XCTAssertEqual(ndt7Test?.settings.url.hostname, "")
-        ndt7Test?.discoverServerTask = nil
-
-        // Server found and saving in Cache.
-        settings = NDT7Settings(url: NDT7URL(hostname: ""))
-        ndt7Test = NDT7Test(settings: settings)
-        session.data = jsonServerData
-        result = false
-        errorResult = nil
-        expectation = XCTestExpectation(description: "Job in main thread")
-        ndt7Test?.serverSetup(session: session, { (error) in
-            result = true
-            errorResult = error
-            XCTAssertNil(error)
-            expectation.fulfill()
-        })
-        wait(for: [expectation], timeout: 10.0)
-        XCTAssertTrue(result)
-        XCTAssertNil(errorResult)
-        XCTAssertNotNil(ndt7Test?.settings.url.server)
-        hostname = try XCTUnwrap(ndt7Test?.settings.url.hostname)
-        XCTAssertEqual(hostname, "ndt-iupui-mlab4-atl06.measurement-lab.org")
-        ndt7Test?.discoverServerTask = nil
-
-        // After one successful server, if we don't get a successful server again and we have NDT7 server cache enabled, we use the last server
-        settings = NDT7Settings(url: NDT7URL(hostname: ""))
-        ndt7Test = NDT7Test(settings: settings)
-        session.data = jsonServerDataNofqdn
-        result = false
-        errorResult = nil
-        expectation = XCTestExpectation(description: "Job in main thread")
-        ndt7Test?.serverSetup(session: session, useNDT7ServerCache: true, { (error) in
-            result = true
-            errorResult = error
-            XCTAssertNil(error)
-            expectation.fulfill()
-        })
-        wait(for: [expectation], timeout: 10.0)
-        XCTAssertTrue(result)
-        XCTAssertNil(errorResult)
-        XCTAssertNotNil(ndt7Test?.settings.url.server)
-        hostname = try XCTUnwrap(ndt7Test?.settings.url.hostname)
-        XCTAssertEqual(hostname, "ndt-iupui-mlab4-atl06.measurement-lab.org")
-        ndt7Test?.discoverServerTask = nil
+        XCTAssertNotNil(ndt7Test.settings.downloadUrl)
+        let hostname = try XCTUnwrap(ndt7Test.settings.hostname)
+        XCTAssertEqual(hostname, "mlab1-atl02.mlab-oti.measurement-lab.org")
+        ndt7Test.discoverServerTask = nil
     }
 
     func testNDT7TestUploader() {
@@ -302,7 +205,7 @@ class NDT7TestTests: XCTestCase {
         let t0 = Date().addingTimeInterval(-10000000)
         let tlast = Date().addingTimeInterval(10000000)
         let count = 123456
-        let settings = NDT7Settings(url: NDT7URL(hostname: "", downloadPath: "", uploadPath: ""))
+        let settings = NDT7Settings()
         let url = URL.init(string: "127.0.0.1")
         let webSocketUpload = WebSocketWrapper(settings: settings, url: url!)!
 
@@ -323,7 +226,7 @@ class NDT7TestTests: XCTestCase {
         let ndt7Test: NDT7Test? = NDT7Test(settings: settings)
         let testInteractionMock = TestInteractionMock()
         ndt7Test?.delegate = testInteractionMock
-        ndt7Test?.webSocketUpload = WebSocketWrapper(settings: settings, url: URL(string: settings.url.uploadPath)!)
+        ndt7Test?.webSocketUpload = WebSocketWrapper(settings: settings, url: URL(string: "http://test.localhost")!)
         ndt7Test?.uploadMessage(socket: ndt7Test!.webSocketUpload!, t0: t0, t1: t1, count: count)
         XCTAssertEqual(testInteractionMock.count, count)
         XCTAssertEqual(testInteractionMock.direction, .upload)
@@ -416,7 +319,7 @@ elapsed: 1,
     }
 
     func testNDT7TestStartDownloadTrue() {
-        let settings = NDT7Settings(url: NDT7URL(hostname: "", downloadPath: "$5^7~c` "))
+        let settings = NDT7Settings()
         let ndt7Test: NDT7Test? = NDT7Test(settings: settings)
         var startDownloadCheck = false
         let completion: (_ error: NSError?) -> Void = { (error) in
@@ -453,7 +356,7 @@ elapsed: 1,
     }
 
     func testNDT7TestStartUploadTrue() {
-        let settings = NDT7Settings(url: NDT7URL(hostname: "", downloadPath: "$5^7~c` "))
+        let settings = NDT7Settings()
         let ndt7Test: NDT7Test? = NDT7Test(settings: settings)
         var startUploadCheck = false
         let completion: (_ error: NSError?) -> Void = { (error) in
@@ -511,20 +414,14 @@ elapsed: 1,
 
     func testNDT7SettingsMeasurementInterval() {
         let settings = NDT7Settings(timeout: NDT7Timeouts(measurement: 5.5))
-        XCTAssertEqual(settings.url.hostname, "")
-        XCTAssertEqual(settings.url.downloadPath, "/ndt/v7/download")
-        XCTAssertEqual(settings.url.uploadPath, "/ndt/v7/upload")
-        XCTAssertTrue(settings.url.wss)
-        XCTAssertTrue(settings.skipTLSCertificateVerification)
         XCTAssertEqual(settings.timeout.measurement, 5.5)
         XCTAssertEqual(settings.timeout.ioTimeout, 7)
         XCTAssertEqual(settings.timeout.downloadTimeout, 15)
         XCTAssertEqual(settings.timeout.uploadTimeout, 15)
-        XCTAssertEqual(settings.headers["Sec-WebSocket-Protocol"], "net.measurementlab.ndt.v7")
     }
 
     func testWebSocketInteraction() {
-        let settings = NDT7Settings(url: NDT7URL(hostname: "", downloadPath: "", uploadPath: ""))
+        let settings = NDT7Settings()
         let url = URL.init(string: "127.0.0.1")
         let webSocketDownload = WebSocketWrapper(settings: settings, url: url!)!
         let webSocketUpload = WebSocketWrapper(settings: settings, url: url!)!


### PR DESCRIPTION
Update the NDT7 client to consume the locate V2 API, including authenticated websocket URLs to call.

This will fix https://github.com/m-lab/ndt7-client-ios/issues/75 and https://github.com/m-lab/ndt7-client-ios/issues/76

I'm working to get access to the published Cocoapod so that we can push this update once it's merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-ios/77)
<!-- Reviewable:end -->
