### PR TITLE
Fixing URLSessionNDT7 build issue on Xcode 13 and Xcode 14 😅 

### DIFF
--- a/Sources/NDT7Settings.swift
+++ b/Sources/NDT7Settings.swift
@@ -156,7 +156,7 @@ extension NDT7Server {
                                                    _ completion: @escaping (_ server: [NDT7Server]?, _ error: NSError?) -> Void) -> URLSessionTaskNDT7 {
         let retry = min(retry, 4)
         let request = Networking.urlRequest(NDT7WebSocketConstants.MLabServerDiscover.url)
-        let task = session.dataTask(with: request as URLRequest) { (data, _, error) -> Void in
+        let task = session.ndt7DataTask(with: request as URLRequest) { (data, _, error) -> Void in
             OperationQueue.current?.name = "net.measurementlab.NDT7.MlabServer.discover"
             guard error?.localizedDescription != "cancelled" else {
                 completion(nil, NDT7TestConstants.cancelledError)

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Protocol for URLSession dataTask
 public protocol URLSessionNDT7 {
     associatedtype DataTaskType: URLSessionTaskNDT7
-  func dataTask(with request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
+  func ndt7DataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
 }
 
 /// Protocol for URLSessionTask
@@ -22,8 +22,8 @@ public protocol URLSessionTaskNDT7 {
 }
 
 extension URLSession: URLSessionNDT7 {
-  public func dataTask(with request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-   dataTask(with: request, completionHandler: completion)
+  public func ndt7DataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+    dataTask(with: request, completionHandler: completionHandler)
   }
 }
 

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -11,7 +11,11 @@ import Foundation
 /// Protocol for URLSession dataTask
 public protocol URLSessionNDT7 {
     associatedtype DataTaskType: URLSessionTaskNDT7
-    func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
+  @available (iOS 16, *)
+  func dataTask(with request: URLRequest, completion: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
+
+  @available(iOS, obsoleted: 16)
+  func dataTask(with request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
 }
 
 /// Protocol for URLSessionTask
@@ -22,6 +26,15 @@ public protocol URLSessionTaskNDT7 {
 }
 
 extension URLSession: URLSessionNDT7 {
+  @available (iOS 16, *)
+  public func dataTask(with request: URLRequest, completion: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+   dataTask(with: request, completionHandler: completion)
+  }
+
+  @available(iOS, obsoleted: 16)
+  public func dataTask(with request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+    dataTask(with: request, completionHandler: completion)
+  }
 }
 
 extension URLSessionTask: URLSessionTaskNDT7 {

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Protocol for URLSession dataTask
 public protocol URLSessionNDT7 {
     associatedtype DataTaskType: URLSessionTaskNDT7
-  func ndt7DataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
+    func ndt7DataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
 }
 
 /// Protocol for URLSessionTask
@@ -22,7 +22,7 @@ public protocol URLSessionTaskNDT7 {
 }
 
 extension URLSession: URLSessionNDT7 {
-  public func ndt7DataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+    public func ndt7DataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
     dataTask(with: request, completionHandler: completionHandler)
   }
 }

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -11,11 +11,7 @@ import Foundation
 /// Protocol for URLSession dataTask
 public protocol URLSessionNDT7 {
     associatedtype DataTaskType: URLSessionTaskNDT7
-  @available (iOS 16, *)
   func dataTask(with request: URLRequest, completion: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
-
-  @available(iOS, obsoleted: 16)
-  func dataTask(with request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
 }
 
 /// Protocol for URLSessionTask
@@ -26,14 +22,8 @@ public protocol URLSessionTaskNDT7 {
 }
 
 extension URLSession: URLSessionNDT7 {
-  @available (iOS 16, *)
   public func dataTask(with request: URLRequest, completion: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
    dataTask(with: request, completionHandler: completion)
-  }
-
-  @available(iOS, obsoleted: 16)
-  public func dataTask(with request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-    dataTask(with: request, completionHandler: completion)
   }
 }
 

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Protocol for URLSession dataTask
 public protocol URLSessionNDT7 {
     associatedtype DataTaskType: URLSessionTaskNDT7
-  func dataTask(with request: URLRequest, completion: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
+  func dataTask(with request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
 }
 
 /// Protocol for URLSessionTask
@@ -22,7 +22,7 @@ public protocol URLSessionTaskNDT7 {
 }
 
 extension URLSession: URLSessionNDT7 {
-  public func dataTask(with request: URLRequest, completion: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+  public func dataTask(with request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
    dataTask(with: request, completionHandler: completion)
   }
 }

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Protocol for URLSession dataTask
 public protocol URLSessionNDT7 {
     associatedtype DataTaskType: URLSessionTaskNDT7
-    func ndt7DataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
+    func ndt7DataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> DataTaskType
 }
 
 /// Protocol for URLSessionTask
@@ -22,7 +22,7 @@ public protocol URLSessionTaskNDT7 {
 }
 
 extension URLSession: URLSessionNDT7 {
-    public func ndt7DataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+    public func ndt7DataTask(with request: URLRequest, completionHandler: @escaping @Sendable  (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
     dataTask(with: request, completionHandler: completionHandler)
   }
 }


### PR DESCRIPTION
So... I got a little carried away and merged https://github.com/m-lab/ndt7-client-ios/pull/85 before testing that it works with Xcode 13. It did not. 😬 

Instead of implicitly conforming to Apple's URLSession method (which can break when API changes), we're now explicitly calling URLSession's `dataTask` method from `ndt7DataTask`. Tested this change on Xcode 13 and 14. ✅ 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-ios/86)
<!-- Reviewable:end -->
